### PR TITLE
Reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/yamacir-kit/meevax.svg?branch=master)](https://travis-ci.org/yamacir-kit/meevax)
 
-Version 0.1.308 in development.
+Version 0.1.309 in development.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/yamacir-kit/meevax.svg?branch=master)](https://travis-ci.org/yamacir-kit/meevax)
 
-Version 0.1.307 in development.
+Version 0.1.308 in development.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/yamacir-kit/meevax.svg?branch=master)](https://travis-ci.org/yamacir-kit/meevax)
 
-Version 0.1.309 in development.
+Version 0.1.310 in development.
 
 ## Installation
 

--- a/include/meevax/system/character.hpp
+++ b/include/meevax/system/character.hpp
@@ -7,19 +7,23 @@
 
 namespace meevax::system
 {
+  using char8_t = char;
+
   struct character
-    : public std::string
+    : public std::basic_string<char8_t>
   {
     template <typename... Ts>
     constexpr character(Ts&&... args)
-      : std::string {std::forward<Ts>(args)...}
+      : std::basic_string<char8_t> {std::forward<Ts>(args)...}
     {}
   };
 
   std::ostream& operator<<(std::ostream& os, const character& c)
   {
-    return os << "\x1B[0;36m#\\" << static_cast<const std::string&>(c) << "\x1b[0m";
+    return os << "\x1B[0;36m#\\" << static_cast<const std::basic_string<char8_t>&>(c) << "\x1b[0m";
   }
+
+  constexpr auto backspace {u8'\b'};
 } // namespace meevax::system
 
 #endif // INCLUDED_MEEVAX_SYSTEM_CHARACTER_HPP

--- a/include/meevax/system/cursor.hpp
+++ b/include/meevax/system/cursor.hpp
@@ -36,7 +36,7 @@ namespace meevax::system
   extern "C" const cursor unit;
 
   template <typename T, typename... Ts>
-  constexpr decltype(auto) make(Ts&&... args)
+  constexpr cursor make(Ts&&... args)
   {
     return cursor::bind<T>(std::forward<Ts>(args)...);
   }

--- a/include/meevax/system/reader.hpp
+++ b/include/meevax/system/reader.hpp
@@ -27,14 +27,16 @@ namespace meevax::system
     template <typename Interner>
     cursor read(Interner&& intern)
     {
-      for (std::string buffer {narrow(get(), ' ')}; *this; buffer.push_back(narrow(get(), ' '))) switch (buffer.back())
+      std::string buffer {};
+
+      // TODO OSTREAM_ITERATOR
+      for (auto key {narrow(get(), ' ')}; *this; key = narrow(get(), ' ')) switch (key)
       {
       case ';':
         ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-        [[fallthrough]];
+        break;
 
       case ' ': case '\t': case '\n':
-        buffer.pop_back();
         break;
 
       case '(':
@@ -99,6 +101,8 @@ namespace meevax::system
         return expand(intern);
 
       default:
+        buffer.push_back(key);
+
         if (auto c {peek()}; is_delimiter(c)) try // delimiter
         {
           if (buffer == ".")

--- a/include/meevax/system/reader.hpp
+++ b/include/meevax/system/reader.hpp
@@ -12,11 +12,13 @@
 
 namespace meevax::system
 {
-  class reader
+  class reader // is character oriented state machine.
     : public std::ifstream
   {
     static inline const cursor x0020 {make<character>(")")},
                                x002E {make<character>(".")};
+
+    using seeker = std::istream_iterator<char8_t>;
 
   public:
     template <typename... Ts>
@@ -29,8 +31,7 @@ namespace meevax::system
     {
       std::string buffer {};
 
-      // TODO OSTREAM_ITERATOR
-      for (auto key {narrow(get(), ' ')}; *this; key = narrow(get(), ' ')) switch (key)
+      for (seeker head {*this}; head != seeker {}; ++head) switch (*head)
       {
       case ';':
         ignore(std::numeric_limits<std::streamsize>::max(), '\n');
@@ -101,7 +102,7 @@ namespace meevax::system
         return expand(intern);
 
       default:
-        buffer.push_back(key);
+        buffer.push_back(*head);
 
         if (auto c {peek()}; is_delimiter(c)) try // delimiter
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -112,9 +112,22 @@ int main()
     const auto evaluation {root.execute(executable)};
     std::cerr << "; " << evaluation << std::endl;
   }
+  catch (const cursor& something)
+  {
+    if (something && something.is<exception>())
+    {
+      std::cerr << something << std::endl;
+      continue;
+    }
+    else
+    {
+      std::cerr << "\x1b[31m[debug] unexpected object thrown: " << something << std::endl;
+      return boost::exit_exception_failure;
+    }
+  }
   catch (const std::runtime_error& error)
   {
-    std::cerr << "\x1B[31m[error] " << error.what() << "\x1B[0m\n\n";
+    std::cerr << "\x1b[31m[fatal] " << error.what() << "\x1B[0m\n\n";
     continue;
   }
 


### PR DESCRIPTION
例外を使ってエラーとして特殊ケースを送出、特殊ケースが現れることが予想されるケースでは適切にcatchされて処理されるけど、そうでない場合（本当にエラーとして現れた場合）は素通りしてトップレベルでcatchされる。
ちょっとUBすれすれになってそうで怖いけど、綺麗なので良し。

例外周りがアドホックなコードになってるのが気になるけど、これは例外システムの仕様が固まってからの課題ということで。